### PR TITLE
Tweak dark-theme colors in calendar view (#268)

### DIFF
--- a/src/Calendars/Calendar.css
+++ b/src/Calendars/Calendar.css
@@ -7,3 +7,11 @@
     margin: 10px 0;
   }
 }
+
+/* tweak some colors for dark theme */
+.theme-dark .rbc-toolbar button:not(:focus):not(:hover):not(.rbc-active) {
+  color: #fff;
+}
+.theme-dark .rbc-now a, .theme-dark .rbc-today a {
+  color: #000;
+}


### PR DESCRIPTION
Some texts were unreadable before when the dark theme was used (like black text on a dark gray button). Change the affected text colors for a better contrast.